### PR TITLE
chore: release v0.77.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.77.2](https://github.com/contentauth/c2pa-cbor/compare/v0.77.1...v0.77.2)
+_31 January 2026_
+
+### Added
+
+* Ensure tagged types are encoded and decoded as tagged ([#10](https://github.com/contentauth/c2pa-cbor/pull/10))
+
 ## [0.77.1](https://github.com/contentauth/c2pa-cbor/compare/v0.77.0...v0.77.1)
 _30 January 2026_
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["cbor", "metadata"]
 license = "MIT OR Apache-2.0"
 name = "c2pa_cbor"
 repository = "https://github.com/contentauth/c2pa-cbor"
-version = "0.77.1"
+version = "0.77.2"
 
 [features]
 # Enable optimal float encoding (f16/f32/f64) instead of always using f64


### PR DESCRIPTION



## 🤖 New release

* `c2pa_cbor`: 0.77.1 -> 0.77.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.77.2](https://github.com/contentauth/c2pa-cbor/compare/v0.77.1...v0.77.2)

_31 January 2026_

### Added

* Ensure tagged types are encoded and decoded as tagged ([#10](https://github.com/contentauth/c2pa-cbor/pull/10))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).