### PR TITLE
feat: Add full deterministic support by default

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -26,6 +26,12 @@ pub struct Decoder<R: Read> {
     recursion_depth: usize,
     max_recursion_depth: usize,
     current_tag: Option<u64>,
+    /// When true, `deserialize_any_impl` notifies the visitor of a CBOR tag
+    /// via `visit_newtype_struct` instead of transparently skipping past it.
+    /// Only safe for a visitor that implements `visit_newtype_struct` (e.g.
+    /// `Value`'s); see [`crate::Value::from_tagged_slice`]. Left `false` by
+    /// default so plain types keep deserializing straight out of tagged CBOR.
+    capture_tags: bool,
 }
 
 /// Safely convert u64 to usize, checking for overflow on 32-bit platforms
@@ -64,7 +70,17 @@ impl<R: Read> Decoder<R> {
             recursion_depth: 0,
             max_recursion_depth: DEFAULT_MAX_DEPTH,
             current_tag: None,
+            capture_tags: false,
         }
+    }
+
+    /// Enable tag-capturing mode (builder pattern): notify the visitor of
+    /// CBOR tags via `visit_newtype_struct` instead of transparently
+    /// skipping past them. Only used internally by
+    /// [`crate::Value::from_tagged_slice`].
+    pub(crate) fn with_capture_tags(mut self, capture: bool) -> Self {
+        self.capture_tags = capture;
+        self
     }
 
     /// Set the maximum allocation size for a single CBOR value (builder pattern)
@@ -390,13 +406,22 @@ impl<R: Read> Decoder<R> {
                 // Store the tag
                 self.current_tag = Some(tag);
 
-                // For maximum compatibility: try visit_map first (for Tagged<T>),
-                // and if that fails, fall back to transparent pass-through (for String, i64, etc.)
-                // We create a special deserializer that tries both approaches
-                let result = serde::Deserializer::deserialize_any(
-                    TaggedValueDeserializer { de: self, tag },
-                    visitor,
-                );
+                let result = if self.capture_tags {
+                    // Tag-aware mode: notify the visitor via
+                    // visit_newtype_struct so it can reconstruct the tag
+                    // (used by Value::from_tagged_slice). Only safe for a
+                    // visitor that implements visit_newtype_struct.
+                    crate::tags::set_tag(Some(tag));
+                    visitor.visit_newtype_struct(TaggedValueDeserializer { de: self, tag })
+                } else {
+                    // For maximum compatibility: try visit_map first (for Tagged<T>),
+                    // and if that fails, fall back to transparent pass-through (for String, i64, etc.)
+                    // We create a special deserializer that tries both approaches
+                    serde::Deserializer::deserialize_any(
+                        TaggedValueDeserializer { de: self, tag },
+                        visitor,
+                    )
+                };
 
                 // Clear the tag after deserialization
                 self.current_tag = None;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -22,11 +22,30 @@ use crate::{Error, Result, constants::*};
 // Encoder
 pub struct Encoder<W: Write> {
     writer: W,
+    /// When true (the default), map and struct entries are buffered and
+    /// written in the bytewise-lexicographic order of their encoded keys,
+    /// per RFC 8949 §4.2.1's Core Deterministic Encoding Requirement.
+    deterministic: bool,
 }
 
 impl<W: Write> Encoder<W> {
     pub fn new(writer: W) -> Self {
-        Encoder { writer }
+        Encoder {
+            writer,
+            deterministic: true,
+        }
+    }
+
+    /// Disable RFC 8949 §4.2.1 map-key sorting, restoring the original
+    /// unsorted, unbuffered fast path for maps and structs.
+    ///
+    /// C2PA requires deterministic encoding, so this is not suitable for
+    /// producing C2PA manifests. It exists for callers who need to match
+    /// serde's declaration/insertion order instead (e.g. byte-for-byte
+    /// compatibility with another encoder) and are willing to give that up.
+    pub fn set_deterministic(mut self, deterministic: bool) -> Self {
+        self.deterministic = deterministic;
+        self
     }
 
     /// Consume the encoder and return the inner writer
@@ -111,7 +130,7 @@ impl<'a, W: Write> serde::Serializer for &'a mut Encoder<W> {
     type SerializeMap = SerializeVec<'a, W>;
     type SerializeSeq = SerializeVec<'a, W>;
     type SerializeStruct = SerializeVec<'a, W>;
-    type SerializeStructVariant = &'a mut Encoder<W>;
+    type SerializeStructVariant = SerializeStructVariantBuf<'a, W>;
     type SerializeTuple = SerializeVec<'a, W>;
     type SerializeTupleStruct = SerializeVec<'a, W>;
     type SerializeTupleVariant = &'a mut Encoder<W>;
@@ -315,22 +334,22 @@ impl<'a, W: Write> serde::Serializer for &'a mut Encoder<W> {
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
-        match len {
-            Some(len) => {
-                // Fast path: length known, write header immediately (no buffering)
-                self.write_type_value(MAJOR_MAP, len as u64)?;
-                Ok(SerializeVec::Direct { encoder: self })
-            }
-            None => {
-                // Slow path: length unknown, buffer key-value pairs until end()
-                // Happens with #[serde(flatten)] or custom map-like types in serde_transcode
-                Ok(SerializeVec::Map {
-                    encoder: self,
-                    buffer: Vec::new(),
-                    pending_key: None,
-                })
-            }
+        // Deterministic encoding requires sorting entries by their encoded key
+        // bytes, which is only possible once every entry has been serialized,
+        // so it always buffers regardless of whether the length is known.
+        if !self.deterministic
+            && let Some(len) = len
+        {
+            // Fast path: length known, write header immediately (no buffering)
+            self.write_type_value(MAJOR_MAP, len as u64)?;
+            return Ok(SerializeVec::Direct { encoder: self });
         }
+        // Slow path: buffer key-value pairs until end()
+        Ok(SerializeVec::Map {
+            encoder: self,
+            buffer: Vec::new(),
+            pending_key: None,
+        })
     }
 
     fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
@@ -347,12 +366,55 @@ impl<'a, W: Write> serde::Serializer for &'a mut Encoder<W> {
         _name: &'static str,
         _variant_index: u32,
         variant: &'static str,
-        len: usize,
+        _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
         self.write_type_value(MAJOR_MAP, 1)?;
         variant.serialize(&mut *self)?;
-        self.write_type_value(MAJOR_MAP, len as u64)?;
-        Ok(self)
+        Ok(SerializeStructVariantBuf {
+            encoder: self,
+            buffer: Vec::new(),
+        })
+    }
+}
+
+/// Buffers the fields of a struct variant so they can be written in
+/// deterministic (sorted-by-key) order once all fields are known, matching
+/// the same requirement enforced for plain maps and structs.
+pub struct SerializeStructVariantBuf<'a, W: Write> {
+    encoder: &'a mut Encoder<W>,
+    buffer: Vec<(Vec<u8>, Vec<u8>)>,
+}
+
+impl<'a, W: Write> serde::ser::SerializeStructVariant for SerializeStructVariantBuf<'a, W> {
+    type Error = crate::Error;
+    type Ok = ();
+
+    fn serialize_field<T: ?Sized + Serialize>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<()> {
+        let deterministic = self.encoder.deterministic;
+        let key_bytes = SerializeVec::<W>::serialize_to_buffer(&key, deterministic)?;
+        let value_bytes = SerializeVec::<W>::serialize_to_buffer(value, deterministic)?;
+        self.buffer.push((key_bytes, value_bytes));
+        Ok(())
+    }
+
+    fn end(self) -> Result<()> {
+        let SerializeStructVariantBuf {
+            encoder,
+            mut buffer,
+        } = self;
+        if encoder.deterministic {
+            buffer.sort_by(|a, b| a.0.cmp(&b.0));
+        }
+        encoder.write_type_value(MAJOR_MAP, buffer.len() as u64)?;
+        for (key_bytes, value_bytes) in buffer {
+            SerializeVec::<W>::write_buffered(encoder, &key_bytes)?;
+            SerializeVec::<W>::write_buffered(encoder, &value_bytes)?;
+        }
+        Ok(())
     }
 }
 
@@ -443,34 +505,17 @@ impl<W: Write> serde::ser::SerializeStruct for &mut Encoder<W> {
     }
 }
 
-impl<W: Write> serde::ser::SerializeStructVariant for &mut Encoder<W> {
-    type Error = crate::Error;
-    type Ok = ();
-
-    fn serialize_field<T: ?Sized + Serialize>(
-        &mut self,
-        key: &'static str,
-        value: &T,
-    ) -> Result<()> {
-        key.serialize(&mut **self)?;
-        value.serialize(&mut **self)
-    }
-
-    fn end(self) -> Result<()> {
-        Ok(())
-    }
-}
-
 // Implementations for SerializeVec (handles buffering for unknown-length collections)
 
 impl<'a, W: Write> SerializeVec<'a, W> {
-    /// Serialize a value to a buffer for later writing
-    fn serialize_to_buffer<T>(value: &T) -> Result<Vec<u8>>
+    /// Serialize a value to a buffer for later writing, inheriting the
+    /// outer encoder's determinism setting for any nested maps/structs
+    fn serialize_to_buffer<T>(value: &T, deterministic: bool) -> Result<Vec<u8>>
     where
         T: ?Sized + Serialize,
     {
         let mut buf = Vec::new();
-        let mut encoder = Encoder::new(&mut buf);
+        let mut encoder = Encoder::new(&mut buf).set_deterministic(deterministic);
         value.serialize(&mut encoder)?;
         Ok(buf)
     }
@@ -492,8 +537,8 @@ impl<'a, W: Write> serde::ser::SerializeSeq for SerializeVec<'a, W> {
     {
         match self {
             SerializeVec::Direct { encoder } => value.serialize(&mut **encoder),
-            SerializeVec::Array { buffer, .. } => {
-                buffer.push(Self::serialize_to_buffer(value)?);
+            SerializeVec::Array { encoder, buffer } => {
+                buffer.push(Self::serialize_to_buffer(value, encoder.deterministic)?);
                 Ok(())
             }
             SerializeVec::Map { .. } => Err(Error::Message(
@@ -557,8 +602,12 @@ impl<'a, W: Write> serde::ser::SerializeMap for SerializeVec<'a, W> {
     {
         match self {
             SerializeVec::Direct { encoder } => key.serialize(&mut **encoder),
-            SerializeVec::Map { pending_key, .. } => {
-                *pending_key = Some(Self::serialize_to_buffer(key)?);
+            SerializeVec::Map {
+                pending_key,
+                encoder,
+                ..
+            } => {
+                *pending_key = Some(Self::serialize_to_buffer(key, encoder.deterministic)?);
                 Ok(())
             }
             SerializeVec::Array { .. } => Err(Error::Message(
@@ -576,9 +625,9 @@ impl<'a, W: Write> serde::ser::SerializeMap for SerializeVec<'a, W> {
             SerializeVec::Map {
                 buffer,
                 pending_key,
-                ..
+                encoder,
             } => {
-                let value_bytes = Self::serialize_to_buffer(value)?;
+                let value_bytes = Self::serialize_to_buffer(value, encoder.deterministic)?;
                 if let Some(key_bytes) = pending_key.take() {
                     buffer.push((key_bytes, value_bytes));
                     Ok(())
@@ -599,13 +648,20 @@ impl<'a, W: Write> serde::ser::SerializeMap for SerializeVec<'a, W> {
             SerializeVec::Direct { .. } => Ok(()),
             SerializeVec::Map {
                 encoder,
-                buffer,
+                mut buffer,
                 pending_key,
             } => {
                 if pending_key.is_some() {
                     return Err(Error::Message(
                         "serialize_key called without serialize_value".to_string(),
                     ));
+                }
+                // RFC 8949 §4.2.1: map keys must be sorted in the bytewise
+                // lexicographic order of their encoded bytes. `Vec<u8>`'s
+                // `Ord` is already a byte-for-byte lexicographic comparison,
+                // so sorting on the encoded key bytes directly satisfies this.
+                if encoder.deterministic {
+                    buffer.sort_by(|a, b| a.0.cmp(&b.0));
                 }
                 // Write definite-length map header now that we know the count
                 encoder.write_type_value(MAJOR_MAP, buffer.len() as u64)?;
@@ -641,11 +697,10 @@ impl<'a, W: Write> serde::ser::SerializeStruct for SerializeVec<'a, W> {
 }
 
 // Convenience functions
-/// Serializes a value to a CBOR byte vector
-pub fn to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+fn to_vec_with<T: Serialize>(value: &T, deterministic: bool) -> Result<Vec<u8>> {
     // Try direct serialization first
     let mut buf = Vec::new();
-    let mut encoder = Encoder::new(&mut buf);
+    let mut encoder = Encoder::new(&mut buf).set_deterministic(deterministic);
     match encoder.encode(value) {
         Ok(()) => Ok(buf),
         Err(Error::Message(ref msg)) if msg.contains("indefinite-length") => {
@@ -653,7 +708,7 @@ pub fn to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>> {
             // This handles #[serde(flatten)] and other cases where size is unknown
             let value = crate::value::to_value(value)?;
             buf.clear();
-            let mut encoder = Encoder::new(&mut buf);
+            let mut encoder = Encoder::new(&mut buf).set_deterministic(deterministic);
             encoder.encode(&value)?;
             Ok(buf)
         }
@@ -661,9 +716,36 @@ pub fn to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>> {
     }
 }
 
-/// Serializes a value to a CBOR writer
+/// Serializes a value to a CBOR byte vector.
+///
+/// Map and struct keys are written in the bytewise-lexicographic order of
+/// their encoded bytes, per RFC 8949 §4.2.1, as required by C2PA.
+pub fn to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+    to_vec_with(value, true)
+}
+
+/// Like [`to_vec`], but preserves declaration/insertion order for map and
+/// struct keys instead of sorting them. Not suitable for producing C2PA
+/// manifests, which require deterministic encoding.
+pub fn to_vec_unordered<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+    to_vec_with(value, false)
+}
+
+/// Serializes a value to a CBOR writer.
+///
+/// Map and struct keys are written in the bytewise-lexicographic order of
+/// their encoded bytes, per RFC 8949 §4.2.1, as required by C2PA.
 pub fn to_writer<W: Write, T: Serialize>(writer: W, value: &T) -> Result<()> {
     let mut encoder = Encoder::new(writer);
+    encoder.encode(value)?;
+    Ok(())
+}
+
+/// Like [`to_writer`], but preserves declaration/insertion order for map and
+/// struct keys instead of sorting them. Not suitable for producing C2PA
+/// manifests, which require deterministic encoding.
+pub fn to_writer_unordered<W: Write, T: Serialize>(writer: W, value: &T) -> Result<()> {
+    let mut encoder = Encoder::new(writer).set_deterministic(false);
     encoder.encode(value)?;
     Ok(())
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -261,13 +261,11 @@ impl<'a, W: Write> serde::Serializer for &'a mut Encoder<W> {
     where
         T: ?Sized + Serialize,
     {
-        // Check if this is a special CBOR tag marker from Tagged<T>
-        if let Some(tag_str) = name.strip_prefix("__cbor_tag_")
-            && let Some(tag_num_str) = tag_str.strip_suffix("__")
-            && let Ok(tag) = tag_num_str.parse::<u64>()
-        {
-            // Write the CBOR tag and then serialize the value
-            self.write_tag(tag)?;
+        // Check if this is the special CBOR tag marker from Tagged<T>/Value::Tag
+        if name == crate::tags::TAG_MARKER_NAME {
+            if let Some(tag) = crate::tags::take_tag() {
+                self.write_tag(tag)?;
+            }
             return value.serialize(self);
         }
 
@@ -408,6 +406,11 @@ impl<'a, W: Write> serde::ser::SerializeStructVariant for SerializeStructVariant
         } = self;
         if encoder.deterministic {
             buffer.sort_by(|a, b| a.0.cmp(&b.0));
+            if buffer.windows(2).any(|w| w[0].0 == w[1].0) {
+                return Err(Error::Message(
+                    "duplicate map key in deterministic CBOR encoding".to_string(),
+                ));
+            }
         }
         encoder.write_type_value(MAJOR_MAP, buffer.len() as u64)?;
         for (key_bytes, value_bytes) in buffer {
@@ -660,8 +663,15 @@ impl<'a, W: Write> serde::ser::SerializeMap for SerializeVec<'a, W> {
                 // lexicographic order of their encoded bytes. `Vec<u8>`'s
                 // `Ord` is already a byte-for-byte lexicographic comparison,
                 // so sorting on the encoded key bytes directly satisfies this.
+                // The RFC also disallows duplicate keys, so that's only
+                // checked in this same deterministic mode.
                 if encoder.deterministic {
                     buffer.sort_by(|a, b| a.0.cmp(&b.0));
+                    if buffer.windows(2).any(|w| w[0].0 == w[1].0) {
+                        return Err(Error::Message(
+                            "duplicate map key in deterministic CBOR encoding".to_string(),
+                        ));
+                    }
                 }
                 // Write definite-length map header now that we know the count
                 encoder.write_type_value(MAJOR_MAP, buffer.len() as u64)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,17 @@
 //!
 //! ## Architecture
 //!
-//! This library uses a **dual-path serialization strategy** for optimal performance:
-//!
-//! - **Fast path**: When collection sizes are known at compile time (the common case),
-//!   data is written directly to the output with zero buffering overhead.
-//! - **Buffering path**: When sizes are unknown (e.g., `#[serde(flatten)]` in `serde_transcode`),
-//!   entries are buffered in memory and written as definite-length once the count is known.
+//! - **Arrays**: When the length is known at compile time (the common case), data is
+//!   written directly to the output with zero buffering overhead. Unknown-length
+//!   sequences (e.g., custom iterators) are buffered and written as definite-length
+//!   once the count is known.
+//! - **Maps and structs**: Entries are always buffered and written in the
+//!   bytewise-lexicographic order of their encoded key bytes, satisfying RFC 8949
+//!   §4.2.1's Core Deterministic Encoding Requirement, which C2PA requires. This
+//!   applies regardless of source order (struct field declaration order, `HashMap`
+//!   iteration order, etc.). Use [`crate::to_vec_unordered`] / [`crate::to_writer_unordered`]
+//!   or [`Encoder::set_deterministic`] to opt out and restore the original
+//!   unsorted, unbuffered fast path.
 //!
 //! This design maintains C2PA's requirement for deterministic, definite-length encoding
 //! while supporting the full serde data model including complex features like flatten.
@@ -85,7 +90,7 @@ pub mod error;
 pub use error::{Error, Result};
 
 pub mod encoder;
-pub use encoder::{Encoder, to_vec, to_writer};
+pub use encoder::{Encoder, to_vec, to_vec_unordered, to_writer, to_writer_unordered};
 
 pub mod decoder;
 // Re-export DOS protection constants for user configuration

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -13,7 +13,7 @@
 
 // Portions derived from serde_cbor (https://github.com/pyfisch/cbor)
 
-use std::{fmt, io::Write, marker::PhantomData};
+use std::{cell::Cell, fmt, io::Write, marker::PhantomData};
 
 use serde::{
     Deserialize, Deserializer, Serialize,
@@ -21,6 +21,29 @@ use serde::{
 };
 
 use crate::{Decoder, Encoder, Result, constants::*};
+
+thread_local! {
+    static CURRENT_TAG: Cell<Option<u64>> = const { Cell::new(None) };
+}
+
+/// Sentinel newtype-struct name used internally to smuggle a runtime CBOR tag
+/// number (any `u64`) across the generic `Serializer`/`Deserializer`
+/// boundary via [`CURRENT_TAG`], since `serialize_newtype_struct` only
+/// accepts a `&'static str` name and can't carry a dynamic value directly.
+/// Contains an interior NUL byte so it can never collide with a real Rust
+/// type name.
+pub(crate) const TAG_MARKER_NAME: &str = "\0c2pa_cbor_tag\0";
+
+/// Stash a tag number to be picked up by the encoder/decoder on the very
+/// next `TAG_MARKER_NAME` newtype-struct call.
+pub(crate) fn set_tag(tag: Option<u64>) {
+    CURRENT_TAG.with(|cell| cell.set(tag));
+}
+
+/// Read and clear the currently stashed tag number, if any.
+pub(crate) fn take_tag() -> Option<u64> {
+    CURRENT_TAG.with(|cell| cell.take())
+}
 
 /// A tagged CBOR value
 #[derive(Debug, Clone, PartialEq)]
@@ -82,8 +105,10 @@ impl<T: for<'de> Deserialize<'de>> Tagged<T> {
     }
 }
 
-// Custom serialization that writes proper CBOR tags
-// The encoder parses strings like "__cbor_tag_N__" and writes CBOR tag N
+// Custom serialization that writes proper CBOR tags for any tag number.
+// `set_tag` stashes the runtime tag number; the encoder's
+// `serialize_newtype_struct` recognizes `TAG_MARKER_NAME`, reads the stashed
+// tag via `take_tag`, and writes the actual CBOR tag before the value.
 impl<T: Serialize> Serialize for Tagged<T> {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
@@ -91,61 +116,10 @@ impl<T: Serialize> Serialize for Tagged<T> {
     {
         match self.tag {
             Some(tag) => {
-                // Map tag numbers to their corresponding marker strings
-                // The encoder's serialize_newtype_struct parses these and writes the actual CBOR tag
-                let tag_str = match tag {
-                    // Standard RFC 8949 tags
-                    0 => "__cbor_tag_0__",   // Date/time string
-                    1 => "__cbor_tag_1__",   // Epoch datetime
-                    2 => "__cbor_tag_2__",   // Positive bignum
-                    3 => "__cbor_tag_3__",   // Negative bignum
-                    4 => "__cbor_tag_4__",   // Decimal fraction
-                    5 => "__cbor_tag_5__",   // Bigfloat
-                    21 => "__cbor_tag_21__", // Expected conversion to base64url
-                    22 => "__cbor_tag_22__", // Expected conversion to base64
-                    23 => "__cbor_tag_23__", // Expected conversion to base16
-                    24 => "__cbor_tag_24__", // Encoded CBOR data item
-                    32 => "__cbor_tag_32__", // URI
-                    33 => "__cbor_tag_33__", // Base64url
-                    34 => "__cbor_tag_34__", // Base64
-                    36 => "__cbor_tag_36__", // MIME
-
-                    // RFC 8746 - Typed arrays (64-87)
-                    64 => "__cbor_tag_64__", // uint8 array
-                    65 => "__cbor_tag_65__", // uint16 big-endian
-                    66 => "__cbor_tag_66__", // uint32 big-endian
-                    67 => "__cbor_tag_67__", // uint64 big-endian
-                    68 => "__cbor_tag_68__", // uint8 clamped
-                    69 => "__cbor_tag_69__", // uint16 little-endian
-                    70 => "__cbor_tag_70__", // uint32 little-endian
-                    71 => "__cbor_tag_71__", // uint64 little-endian
-                    72 => "__cbor_tag_72__", // sint8
-                    73 => "__cbor_tag_73__", // sint16 big-endian
-                    74 => "__cbor_tag_74__", // sint32 big-endian
-                    75 => "__cbor_tag_75__", // sint64 big-endian
-                    77 => "__cbor_tag_77__", // sint16 little-endian
-                    78 => "__cbor_tag_78__", // sint32 little-endian
-                    79 => "__cbor_tag_79__", // sint64 little-endian
-                    80 => "__cbor_tag_80__", // float16 big-endian
-                    81 => "__cbor_tag_81__", // float32 big-endian
-                    82 => "__cbor_tag_82__", // float64 big-endian
-                    83 => "__cbor_tag_83__", // float128 big-endian
-                    84 => "__cbor_tag_84__", // float16 little-endian
-                    85 => "__cbor_tag_85__", // float32 little-endian
-                    86 => "__cbor_tag_86__", // float64 little-endian
-                    87 => "__cbor_tag_87__", // float128 little-endian
-
-                    _ => {
-                        // Unsupported tag number - use encode_tagged helper functions instead
-                        use serde::ser::Error;
-                        return Err(Error::custom(format!(
-                            "Tag {} not supported via Tagged<T>. Use encode_tagged() helper function for arbitrary tags.",
-                            tag
-                        )));
-                    }
-                };
-
-                serializer.serialize_newtype_struct(tag_str, &self.value)
+                set_tag(Some(tag));
+                let result = serializer.serialize_newtype_struct(TAG_MARKER_NAME, &self.value);
+                set_tag(None);
+                result
             }
             None => {
                 // No tag, just serialize the value directly
@@ -697,5 +671,18 @@ mod tests {
 
         // Verify the bytes are little-endian
         assert!(buf.len() >= 6); // tag + header + 6 bytes of data
+    }
+
+    #[test]
+    fn test_tagged_serialize_arbitrary_tag_number() {
+        // Previously, tags outside a hardcoded whitelist (~30 registered RFC
+        // tags) errored with "not supported via Tagged<T>". Any tag number
+        // now works.
+        let tagged = Tagged::new(Some(123456), "custom".to_string());
+        let cbor = crate::to_vec(&tagged).unwrap();
+
+        let decoded = Tagged::<String>::from_tagged_slice(&cbor).unwrap();
+        assert_eq!(decoded.tag, Some(123456));
+        assert_eq!(decoded.value, "custom");
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -81,10 +81,12 @@ impl Serialize for Value {
             Value::Text(s) => serializer.serialize_str(s),
             Value::Array(a) => a.serialize(serializer),
             Value::Map(m) => m.serialize(serializer),
-            Value::Tag(_tag, _value) => {
-                // For now, serialize the inner value
-                // Full tag support would require custom CBOR encoding
-                _value.serialize(serializer)
+            Value::Tag(tag, value) => {
+                crate::tags::set_tag(Some(*tag));
+                let result =
+                    serializer.serialize_newtype_struct(crate::tags::TAG_MARKER_NAME, value);
+                crate::tags::set_tag(None);
+                result
             }
         }
     }
@@ -213,6 +215,21 @@ impl<'de> Deserialize<'de> for Value {
                 }
                 Ok(Value::Map(map))
             }
+
+            // Only reached when the decoder is in tag-capturing mode (see
+            // `Value::from_tagged_slice`); the tag number was stashed by the
+            // decoder just before this call.
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let tag = crate::tags::take_tag();
+                let inner = deserializer.deserialize_any(self)?;
+                Ok(match tag {
+                    Some(tag) => Value::Tag(tag, Box::new(inner)),
+                    None => inner,
+                })
+            }
         }
 
         deserializer.deserialize_any(ValueVisitor)
@@ -327,6 +344,32 @@ impl Value {
             Value::Tag(tag, value) => Some((*tag, value)),
             _ => None,
         }
+    }
+
+    /// Deserialize CBOR bytes into a `Value`, reconstructing any CBOR tags
+    /// (major type 6) as `Value::Tag` instead of transparently dropping them.
+    ///
+    /// This differs from decoding a `Value` via [`crate::from_slice`], which
+    /// intentionally ignores tags so that plain types (`String`, `i64`, ...)
+    /// can be decoded straight out of tagged CBOR without a wrapper type.
+    /// That transparent behavior is unavailable in this tag-aware mode, so
+    /// it's only offered for `Value` specifically, not as a general decoder
+    /// option.
+    ///
+    /// # Example
+    /// ```
+    /// use c2pa_cbor::{Value, to_vec};
+    ///
+    /// let tagged = Value::Tag(32, Box::new(Value::Text("https://example.com".to_string())));
+    /// let bytes = to_vec(&tagged).unwrap();
+    ///
+    /// let decoded = Value::from_tagged_slice(&bytes).unwrap();
+    /// assert_eq!(decoded, tagged);
+    /// ```
+    pub fn from_tagged_slice(bytes: &[u8]) -> crate::Result<Value> {
+        crate::Decoder::from_slice(bytes)
+            .with_capture_tags(true)
+            .decode()
     }
 }
 
@@ -1222,5 +1265,65 @@ mod tests {
 
         let decoded: ComplexEnum = from_value(value).unwrap();
         assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn test_value_tag_encodes_actual_cbor_tag() {
+        let value = Value::Tag(32, Box::new(Value::Text("https://example.com".to_string())));
+        let bytes = to_vec(&value).unwrap();
+
+        // Tag 32 is encoded as 0xd8 0x20, followed by the text string
+        assert_eq!(bytes[0], 0xd8);
+        assert_eq!(bytes[1], 0x20);
+    }
+
+    #[test]
+    fn test_value_tag_round_trips_via_from_tagged_slice() {
+        let value = Value::Tag(32, Box::new(Value::Text("https://example.com".to_string())));
+        let bytes = to_vec(&value).unwrap();
+
+        let decoded = Value::from_tagged_slice(&bytes).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn test_value_tag_transparent_via_plain_from_slice() {
+        // Plain from_slice (the default, non-tag-aware path) intentionally
+        // drops the tag, matching how any other type transparently ignores
+        // a leading CBOR tag.
+        let value = Value::Tag(32, Box::new(Value::Text("https://example.com".to_string())));
+        let bytes = to_vec(&value).unwrap();
+
+        let decoded: Value = from_slice(&bytes).unwrap();
+        assert_eq!(decoded, Value::Text("https://example.com".to_string()));
+    }
+
+    #[test]
+    fn test_value_tag_nested_round_trips() {
+        let value = Value::Array(vec![
+            Value::Integer(1),
+            Value::Tag(1, Box::new(Value::Integer(1705315800))),
+            Value::Tag(
+                999,
+                Box::new(Value::Map(BTreeMap::from([(
+                    Value::Text("k".to_string()),
+                    Value::Bool(true),
+                )]))),
+            ),
+        ]);
+        let bytes = to_vec(&value).unwrap();
+
+        let decoded = Value::from_tagged_slice(&bytes).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn test_value_tag_arbitrary_tag_number() {
+        // Previously, only a whitelisted set of tag numbers (0-87ish) could
+        // be encoded at all; arbitrary tags now work too.
+        let value = Value::Tag(123456, Box::new(Value::Integer(1)));
+        let bytes = to_vec(&value).unwrap();
+        let decoded = Value::from_tagged_slice(&bytes).unwrap();
+        assert_eq!(decoded, value);
     }
 }

--- a/tests/deterministic_encoding.rs
+++ b/tests/deterministic_encoding.rs
@@ -140,6 +140,54 @@ fn encoder_set_deterministic_false_matches_to_vec_unordered() {
 }
 
 #[test]
+fn duplicate_keys_are_rejected_in_deterministic_mode() {
+    // #[serde(flatten)] can produce a map with a key that collides with a
+    // sibling field's name; RFC 8949 §4.2.1 forbids duplicate keys.
+    #[derive(Serialize)]
+    struct Outer {
+        name: String,
+        #[serde(flatten)]
+        extra: HashMap<String, String>,
+    }
+
+    let mut extra = HashMap::new();
+    extra.insert("name".to_string(), "duplicate!".to_string());
+    let outer = Outer {
+        name: "original".to_string(),
+        extra,
+    };
+
+    let err = to_vec(&outer).unwrap_err();
+    assert!(err.to_string().contains("duplicate"), "{}", err);
+}
+
+#[test]
+fn duplicate_keys_are_allowed_in_unordered_mode() {
+    use std::collections::HashMap;
+
+    #[derive(Serialize)]
+    struct Outer {
+        name: String,
+        #[serde(flatten)]
+        extra: HashMap<String, String>,
+    }
+
+    let mut extra = HashMap::new();
+    extra.insert("name".to_string(), "duplicate!".to_string());
+    let outer = Outer {
+        name: "original".to_string(),
+        extra,
+    };
+
+    // Duplicate-key rejection only applies in deterministic mode.
+    let bytes = to_vec_unordered(&outer).unwrap();
+    assert_eq!(
+        hex(&bytes),
+        "a2646e616d65686f726967696e616c646e616d656a6475706c696361746521"
+    );
+}
+
+#[test]
 fn nested_maps_are_sorted_recursively() {
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     struct Inner {

--- a/tests/deterministic_encoding.rs
+++ b/tests/deterministic_encoding.rs
@@ -1,0 +1,167 @@
+// Copyright 2026 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+//! Tests for RFC 8949 §4.2.1 Core Deterministic Encoding Requirement:
+//! map/struct keys must be written in the bytewise-lexicographic order of
+//! their encoded bytes.
+
+use std::collections::HashMap;
+
+use c2pa_cbor::{Encoder, Value, from_slice, to_vec, to_vec_unordered};
+use serde::{Deserialize, Serialize};
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+#[test]
+fn struct_fields_are_sorted_by_encoded_key_bytes() {
+    // Declared out of alphabetical order; "b" and "aa" also probe the case
+    // where naive string comparison would disagree with CBOR's bytewise
+    // order (shorter keys' length-encoding byte sorts first).
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct S {
+        zebra: i32,
+        apple: i32,
+        b: i32,
+        aa: i32,
+    }
+
+    let s = S {
+        zebra: 1,
+        apple: 2,
+        b: 3,
+        aa: 4,
+    };
+
+    let encoded = to_vec(&s).unwrap();
+    // Expected key order: "b" (len 1, header sorts lowest), "aa" (len 2),
+    // "apple" (len 5), "zebra" (len 5, tie-broken bytewise: 'a' < 'z').
+    assert_eq!(
+        hex(&encoded),
+        "a461620362616104656170706c6502657a6562726101"
+    );
+
+    let decoded: S = from_slice(&encoded).unwrap();
+    assert_eq!(decoded, s);
+}
+
+#[test]
+fn hashmap_keys_are_sorted_regardless_of_insertion_order() {
+    let mut map = HashMap::new();
+    map.insert("zebra".to_string(), 1);
+    map.insert("apple".to_string(), 2);
+    map.insert("b".to_string(), 3);
+    map.insert("aa".to_string(), 4);
+
+    let encoded = to_vec(&map).unwrap();
+    assert_eq!(
+        hex(&encoded),
+        "a461620362616104656170706c6502657a6562726101"
+    );
+}
+
+#[test]
+fn mixed_sign_integer_keys_follow_cbor_byte_order_not_numeric_order() {
+    // CBOR sorts by encoded bytes: unsigned ints (major type 0) always sort
+    // before negative ints (major type 1), regardless of numeric value.
+    // A naive numeric/Ord-based sort would put -5 before 3.
+    let mut map = std::collections::BTreeMap::new();
+    map.insert(Value::Integer(3), Value::Bool(true));
+    map.insert(Value::Integer(-5), Value::Bool(false));
+    let value = Value::Map(map);
+
+    let encoded = to_vec(&value).unwrap();
+    // {3: true, -5: false} -> a2 03 f5 24 f4
+    assert_eq!(hex(&encoded), "a203f524f4");
+}
+
+#[test]
+fn enum_struct_variant_fields_are_sorted() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    enum E {
+        Variant { zebra: i32, apple: i32 },
+    }
+
+    let e = E::Variant { zebra: 1, apple: 2 };
+    let encoded = to_vec(&e).unwrap();
+    // {"Variant": {"apple": 2, "zebra": 1}}
+    assert_eq!(
+        hex(&encoded),
+        "a16756617269616e74a2656170706c6502657a6562726101"
+    );
+
+    let decoded: E = from_slice(&encoded).unwrap();
+    assert_eq!(decoded, e);
+}
+
+#[test]
+fn to_vec_unordered_preserves_declaration_order() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct S {
+        zebra: i32,
+        apple: i32,
+    }
+
+    let s = S { zebra: 1, apple: 2 };
+
+    let encoded = to_vec_unordered(&s).unwrap();
+    // Declaration order preserved: zebra, then apple.
+    assert_eq!(hex(&encoded), "a2657a6562726101656170706c6502");
+
+    let decoded: S = from_slice(&encoded).unwrap();
+    assert_eq!(decoded, s);
+}
+
+#[test]
+fn encoder_set_deterministic_false_matches_to_vec_unordered() {
+    #[derive(Serialize)]
+    struct S {
+        zebra: i32,
+        apple: i32,
+    }
+    let s = S { zebra: 1, apple: 2 };
+
+    let mut buf = Vec::new();
+    let mut encoder = Encoder::new(&mut buf).set_deterministic(false);
+    encoder.encode(&s).unwrap();
+
+    assert_eq!(hex(&buf), hex(&to_vec_unordered(&s).unwrap()));
+}
+
+#[test]
+fn nested_maps_are_sorted_recursively() {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Inner {
+        z: i32,
+        a: i32,
+    }
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Outer {
+        z: Inner,
+        a: Inner,
+    }
+
+    let outer = Outer {
+        z: Inner { z: 1, a: 2 },
+        a: Inner { z: 3, a: 4 },
+    };
+
+    let encoded = to_vec(&outer).unwrap();
+    // Outer sorted: a, z. Each inner also sorted: a, z.
+    // {"a": {"a": 4, "z": 3}, "z": {"a": 2, "z": 1}}
+    assert_eq!(hex(&encoded), "a26161a2616104617a03617aa2616102617a01");
+
+    let decoded: Outer = from_slice(&encoded).unwrap();
+    assert_eq!(decoded, outer);
+}


### PR DESCRIPTION
Sort map and struct keys deterministically per RFC 8949 §4.2.1

Map, struct, and struct-variant entries are now buffered and written
in bytewise-lexicographic order of their encoded key bytes by default,
as C2PA requires. Arrays keep their existing zero-copy fast path since
element order is never reordered.

Adds Encoder::set_deterministic(false) and to_vec_unordered/
to_writer_unordered to opt out and restore the original unsorted,
unbuffered behavior for callers who need it.

Fix duplicate map keys and Value::Tag encoding for RFC 8949 compliance

Reject duplicate map/struct keys in deterministic mode, since RFC 8949
§4.2.1 forbids them (only enforced when deterministic; unordered mode
is unaffected).

Fix Value::Tag, which previously serialized its inner value and
silently dropped the tag. Replace Tagged<T>'s hardcoded whitelist of
~30 tag numbers with a general mechanism (thread-local tag slot + a
single sentinel marker name) that works for any u64 tag, matching the
approach serde_cbor uses. Value::Tag now emits real CBOR tag bytes on
encode, and a new opt-in Decoder::with_capture_tags / Value::
from_tagged_slice reconstructs Value::Tag (including nested tags) on
decode, without changing the default from_slice behavior of
transparently skipping tags for plain types.