### PR TITLE
fix:  #22 deserialization for CBOR floats

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -804,6 +804,23 @@ impl<'de, 'a, R: Read> serde::Deserializer<'de> for PrefetchedDeserializer<'a, R
             MAJOR_SIMPLE => match self.info {
                 FALSE => visitor.visit_bool(false),
                 TRUE => visitor.visit_bool(true),
+                UNDEFINED => visitor.visit_unit(),
+                FLOAT16 => {
+                    let mut buf = [0u8; 2];
+                    self.de.reader.read_exact(&mut buf)?;
+                    let f16_value = half::f16::from_be_bytes(buf);
+                    visitor.visit_f32(f16_value.to_f32())
+                }
+                FLOAT32 => {
+                    let mut buf = [0u8; 4];
+                    self.de.reader.read_exact(&mut buf)?;
+                    visitor.visit_f32(f32::from_be_bytes(buf))
+                }
+                FLOAT64 => {
+                    let mut buf = [0u8; 8];
+                    self.de.reader.read_exact(&mut buf)?;
+                    visitor.visit_f64(f64::from_be_bytes(buf))
+                }
                 _ => Err(Error::Syntax("Invalid simple type in option".to_string())),
             },
             _ => Err(Error::Syntax("Unsupported type in option".to_string())),

--- a/tests/test_option_handling.rs
+++ b/tests/test_option_handling.rs
@@ -514,3 +514,34 @@ fn test_serialization_paths() {
     // Both produce valid definite-length CBOR (required for C2PA)
     // The difference is internal: fast path writes directly, buffered path collects first
 }
+
+// Regression test for https://github.com/contentauth/c2pa-cbor/issues/22
+// PrefetchedDeserializer (used for Option<T>) didn't handle CBOR floats
+// (major type 7, info 25/26/27), only booleans.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct Shape {
+    width: Option<f64>,
+    height: Option<f64>,
+    scale: Option<f32>,
+}
+
+#[test]
+fn test_option_float_round_trip() {
+    let with_values = Shape {
+        width: Some(12.5),
+        height: Some(0.0),
+        scale: Some(2.5),
+    };
+    let cbor = c2pa_cbor::to_vec(&with_values).expect("serialize");
+    let decoded: Shape = c2pa_cbor::from_slice(&cbor).expect("deserialize");
+    assert_eq!(with_values, decoded);
+
+    let all_none = Shape {
+        width: None,
+        height: None,
+        scale: None,
+    };
+    let cbor = c2pa_cbor::to_vec(&all_none).expect("serialize");
+    let decoded: Shape = c2pa_cbor::from_slice(&cbor).expect("deserialize");
+    assert_eq!(all_none, decoded);
+}


### PR DESCRIPTION
PrefetchedDeserializer, used when deserializing Option<T>, only handled booleans for CBOR major type 7 (simple/float) and errored on floats (info 25/26/27) and undefined. This broke any struct with an optional float field, e.g. Option<f64> shape dimensions.

## Changes in this pull request
_Give a narrative description of what has been changed._

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
